### PR TITLE
Don't cleanCloud by default

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -59,10 +59,10 @@ func (d *gcpVolDriver) Create(r volume.Request) volume.Response {
 		return volume.Response{Err: err.Error()}
 	}
 	// Refer volumeName <-> gcsVolumes
-	cleanCloud := true
+	cleanCloud := false
 	val, ok := r.Options["clean_cloud_bucket"]
-	if ok && val == "no" {
-		cleanCloud = false
+	if ok && val == "yes" {
+		cleanCloud = true
 	}
 	d.mountedBuckets[r.Name] = &gcsVolumes{
 		volume: &volume.Volume{


### PR DESCRIPTION
In current implementation, `cleanCloud` is on by default. It might lead to important data being lost which is probably undesirable.